### PR TITLE
Adds GenericArbitrary

### DIFF
--- a/generic-arbitrary.cabal
+++ b/generic-arbitrary.cabal
@@ -23,6 +23,6 @@ tested-with:         GHC == 7.10.3
 
 library
   exposed-modules:     Test.QuickCheck.Arbitrary.Generic
-  build-depends:       QuickCheck >= 2.8, base >=4.8 && <5
+  build-depends:       QuickCheck >= 2.14, base >=4.8 && <5
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,5 @@
 resolver: lts-6.30
 
 extra-deps:
-  - git: https://github.com/tmortiboy/quickcheck.git
-    commit: ab1100a7c7449e7944288b86fe1702e9c98ca5d3
+  - QuickCheck-2.14
   - splitmix-0.0.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,6 @@
 resolver: lts-6.30
+
+extra-deps:
+  - git: https://github.com/tmortiboy/quickcheck.git
+    commit: ab1100a7c7449e7944288b86fe1702e9c98ca5d3
+  - splitmix-0.0.4


### PR DESCRIPTION
I think we can reduce the boiler plate by using `DerivingVia` language extension:

```haskell
data Foo = Foo
  { _fooX :: X
  , _fooY :: Y
  } deriving (Generic)
    deriving (Arbitrary) via GenericArbitrary Foo
```

This also has the added benefit of being able to automatically use types that derive `Generic` but not `Arbitrary` in property tests, eg:

```haskell
prop "Should do something" $ \(GenericArbitrary someoneElsesType) ->
   ...
```

This is not quite ready for merge as this change requires `GSubterms` and `RecursivelyShrink` to be exported from `Test.QuickCheck.Arbitrary`, but I have submitted a PR to them and wanted to get your feedback.

https://github.com/nick8325/quickcheck/pull/290