### PR TITLE
Deriving via newtype

### DIFF
--- a/generic-arbitrary.cabal
+++ b/generic-arbitrary.cabal
@@ -25,6 +25,6 @@ tested-with:         GHC == 7.10.3
 
 library
   exposed-modules:     Test.QuickCheck.Arbitrary.Generic
-  build-depends:       QuickCheck >= 2.8, base >=4.8 && <5
+  build-depends:       QuickCheck >= 2.14, base >=4.8 && <5
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Test/QuickCheck/Arbitrary/Generic.hs
+++ b/src/Test/QuickCheck/Arbitrary/Generic.hs
@@ -15,6 +15,16 @@ instance Arbitrary Foo where
   shrink = genericShrink
 @
 
+This instance can also be derived using DerivingVia language extension
+
+@
+data Foo = Foo
+  { _fooX :: X
+  , _fooY :: Y
+  } deriving (Generic)
+    deriving (Arbitrary) via GenericArbitrary Foo
+@
+
 The generated 'arbitrary' method is equivalent to
 
 @Foo <$> arbitrary <*> arbitrary@.
@@ -22,16 +32,31 @@ The generated 'arbitrary' method is equivalent to
 -}
 
 module Test.QuickCheck.Arbitrary.Generic
-  ( Arbitrary(..)
+  ( GenericArbitrary(..)
+  , Arbitrary(..)
   , genericArbitrary
   , genericShrink
   ) where
 
 import Control.Applicative
+import Data.Coerce (coerce)
 import Data.Proxy
 import GHC.Generics as G
 import GHC.TypeLits
 import Test.QuickCheck as QC
+import Test.QuickCheck.Arbitrary (GSubterms, RecursivelyShrink)
+
+newtype GenericArbitrary a = GenericArbitrary { unGenericArbitrary :: a }
+  deriving (Show, Eq)
+
+instance
+  ( Generic a,
+    GArbitrary (Rep a),
+    RecursivelyShrink (Rep a),
+    GSubterms (Rep a) a
+  ) => Arbitrary (GenericArbitrary a) where
+  arbitrary = coerce (genericArbitrary :: Gen a)
+  shrink = coerce (genericShrink :: a -> [a])
 
 class GArbitrary a where
   gArbitrary :: QC.Gen (a x)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,5 @@
 resolver: lts-6.30
+
+extra-deps:
+  - QuickCheck-2.14
+  - splitmix-0.0.5


### PR DESCRIPTION
This essentially a rebased version of #6.

Adds a `newtype` wrapper to work with `DerivingVia`.

