### PR TITLE
Add FlexibleContexts to support GHC 9.2

### DIFF
--- a/src/Test/QuickCheck/Arbitrary/Generic.hs
+++ b/src/Test/QuickCheck/Arbitrary/Generic.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE UndecidableInstances, TypeOperators, DataKinds, TypeFamilies, ScopedTypeVariables#-}
+{-# LANGUAGE FlexibleContexts, UndecidableInstances, TypeOperators, DataKinds, TypeFamilies, ScopedTypeVariables#-}
 
 {- |
 


### PR DESCRIPTION
This tiny PR allows `generic-arbitrary` to build with ghc 9.2.1.

https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations

Related issue: #12 