### PR TITLE
Prevent resize from being called with a negative number

### DIFF
--- a/src/Test/QuickCheck/Arbitrary/Generic.hs
+++ b/src/Test/QuickCheck/Arbitrary/Generic.hs
@@ -82,8 +82,8 @@ type family SumLen a :: Nat where
 instance (GArbitrary a, GArbitrary b, KnownNat (SumLen a), KnownNat (SumLen b)
          ) => GArbitrary (a G.:+: b) where
   gArbitrary = frequency
-    [ (lfreq, G.L1 <$> QC.scale pred gArbitrary)
-    , (rfreq, G.R1 <$> QC.scale pred gArbitrary) ]
+    [ (lfreq, G.L1 <$> QC.scale (max 0 . pred) gArbitrary)
+    , (rfreq, G.R1 <$> QC.scale (max 0 . pred) gArbitrary) ]
     where
       lfreq = fromIntegral $ natVal (Proxy :: Proxy (SumLen a))
       rfreq = fromIntegral $ natVal (Proxy :: Proxy (SumLen b))


### PR DESCRIPTION
Without this patch this error can occur
```
       *** Failed! (after 2 tests and 8 shrinks):
       Exception while generating shrink-list:
         Test.QuickCheck.resize: negative size
         CallStack (from HasCallStack):
           error, called at src/Test/QuickCheck/Gen.hs:135:22 in QuickCheck-2.14.2-d7ccc9b265479da84d29b38338ff823e03e3d4c8a90b9f8cdb82b74ac9ff037e:Test.QuickCheck.Gen
         CallStack (from -prof):
           Test.QuickCheck.Gen.resize (src/Test/QuickCheck/Gen.hs:(135,1)-(136,42))
           Test.QuickCheck.Gen.CAF (<entire-module>)
```

A stack trace reveals the call to `resize` with a negative value to be inside `genericArbitrary`

```
*** Exception (reporting due to +RTS -xc): (THUNK_2_0), stack trace: 
  Test.QuickCheck.Gen.resize,
  called from Test.QuickCheck.Gen.CAF
  --> evaluated by: Test.QuickCheck.Gen.resize,
  called from Test.QuickCheck.Gen.sized,
  called from Test.QuickCheck.Gen.scale,
  called from Test.QuickCheck.Gen.frequency,
  called from Test.QuickCheck.Arbitrary.Generic.genericArbitrary,
  called from Mapbox.Style.QuickCheck.arbitrary,
  called from Test.QuickCheck.Property.forAllShrinkBlind,
  called from Test.Hspec.QuickCheck.prop,
  called from Mapbox.TestUtil.laxJsonProp,
  called from Mapbox.StyleSpec.spec,
  called from Test.Hspec.Core.Tree.bimapTree,
  called from Test.Hspec.Core.Tree.bimapForest,
  called from Test.Hspec.Core.Clock.measure,
  called from Control.Concurrent.Async.async,
  called from Test.Hspec.Core.Runner.Eval.runFormatter,
  called from Test.Hspec.Core.Runner.runSpec,
  called from Test.Hspec.Core.Runner.hspec,
  called from Main.main
```

This patch prevents the error